### PR TITLE
Add a pre-commit hook definition

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: markdown-table-formatter
+  name: markdown-table-formatter
+  description: Format Markdown tables to a consistent column width.
+  entry: markdown-table-formatter
+  language: node
+  types: [markdown]


### PR DESCRIPTION
Adds a `.pre-commit-hooks.yaml` so the formatter can be used directly as a [pre-commit](https://pre-commit.com) hook:

```yaml
- repo: https://github.com/nvuillam/markdown-table-formatter
  rev: v1.7.0
  hooks:
  - id: markdown-table-formatter
```

Today projects have to wrap the CLI in a `repo: local` hook (via `npx` or a system install) to run it before a commit. This one small file lets them consume it the standard way, pinned by `rev`, with pre-commit managing the install.

The hook runs the existing bin over staged Markdown files and formats their tables in place.